### PR TITLE
Fix URL for Edit on GitHub and Share button position in mobile

### DIFF
--- a/src/components/__snapshots__/footer.test.tsx.snap
+++ b/src/components/__snapshots__/footer.test.tsx.snap
@@ -44,6 +44,12 @@ exports[`Footer Complete 1`] = `
   display: inline-flex;
 }
 
+@media (max-width:60rem) {
+  .emotion-5 {
+    margin-top: 1em;
+  }
+}
+
 .emotion-4 {
   color: black;
   -webkit-text-decoration: none;
@@ -57,12 +63,6 @@ exports[`Footer Complete 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-@media (max-width:60rem) {
-  .emotion-4 {
-    margin-top: 1em;
-  }
 }
 
 .emotion-3 {
@@ -184,6 +184,12 @@ exports[`Footer Only Patreon 1`] = `
   display: inline-flex;
 }
 
+@media (max-width:60rem) {
+  .emotion-3 {
+    margin-top: 1em;
+  }
+}
+
 .emotion-2 {
   fontsize: 0.9em;
 }
@@ -275,6 +281,12 @@ exports[`Footer Only Repository 1`] = `
   display: inline-flex;
 }
 
+@media (max-width:60rem) {
+  .emotion-2 {
+    margin-top: 1em;
+  }
+}
+
 .emotion-1 {
   color: black;
   -webkit-text-decoration: none;
@@ -288,12 +300,6 @@ exports[`Footer Only Repository 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-@media (max-width:60rem) {
-  .emotion-1 {
-    margin-top: 1em;
-  }
 }
 
 .emotion-0 {

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -41,7 +41,14 @@ function Footer(props: {
             <Patreon />
           </div>
         )}
-        <div css={{ display: "inline-flex" }}>
+        <div
+          css={{
+            display: "inline-flex",
+            "@media (max-width: 60rem)": {
+              marginTop: "1em"
+            }
+          }}
+        >
           {props.children}
           {props.repositoryPath && (
             <a
@@ -53,10 +60,7 @@ function Footer(props: {
                 textDecoration: "none",
                 fontSize: "0.8em",
                 display: "inline-flex",
-                alignItems: "center",
-                "@media (max-width: 60rem)": {
-                  marginTop: "1em"
-                }
+                alignItems: "center"
               }}
             >
               {state.i18n.footer.editOnGitHub}{" "}

--- a/src/utils/parse-path.ts
+++ b/src/utils/parse-path.ts
@@ -25,7 +25,7 @@ function parsePath(path: string, { isSlide = false }: config = {}): IPath {
 }
 
 function parseRepositoryPath(repository: string, filePath: string): string {
-  return resolve(resolve(repository, "edit/master"), filePath);
+  return resolve(resolve(repository, "edit/master/"), filePath);
 }
 
 export { parsePath, parseRepositoryPath, IPath };


### PR DESCRIPTION
Adds `/` to `edit/master` to `Edit on Github` button

Moving a media query to the container of the Edit and Share button