### PR TITLE
Set overflow-x to auto

### DIFF
--- a/src/components/html/__snapshots__/code.test.tsx.snap
+++ b/src/components/html/__snapshots__/code.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Code Pre 1`] = `
 }
 
 .emotion-1 {
-  overflow-x: scroll;
+  overflow-x: auto;
   max-height: none;
 }
 

--- a/src/components/html/code.tsx
+++ b/src/components/html/code.tsx
@@ -28,7 +28,7 @@ function Pre({ heightLimit = false, ...props }: any) {
       <pre
         {...props}
         css={{
-          overflowX: "scroll",
+          overflowX: "auto",
           maxHeight: heightLimit ? "30vh" : "none",
           code: {
             color: "black",


### PR DESCRIPTION
Changing `overflow-x` to `auto` instead of `scroll` because the scrollbar was shown on Windows devices when unnecessary.