### PR TITLE
Prepend /pages to custom pages ogurl

### DIFF
--- a/src/builders/pages.tsx
+++ b/src/builders/pages.tsx
@@ -55,7 +55,7 @@ function pageBuilder(state: IState) {
       { state }
     );
     const html: string = await render(
-      <Document data={page} path={page.path} content={renderedContent} />,
+      <Document data={page} path={join("/pages", page.path)} content={renderedContent} />,
       { state }
     );
     await makeDir(resolve(join("./public", page.path)));

--- a/src/components/document.tsx
+++ b/src/components/document.tsx
@@ -8,7 +8,11 @@ import { IArticle } from "../getters/articles";
 
 function formatURL(domain: string, path: string): string {
   if (!path) return domain;
-  return `${domain}/${path.slice(1, path.indexOf(".mdx"))}/`;
+  const isCustomPage = path.includes("/pages");
+  return `${domain}/${path.slice(
+    isCustomPage ? path.indexOf("/pages") + 7 : 1,
+    path.indexOf(".mdx")
+  )}/`;
 }
 
 function formatOGURL(path: string, domain?: string): string {


### PR DESCRIPTION
I've noticed that custom pages should have `/pages/` before the actual path for the OGURL to match the path created by `@contentz/social` but shouldn't add them to the actual URL, that's why I'm making a validation in `formatURL`

I want to update the `contentz` version of the Contentz Website, that's why I'm fixing these issues