### PR TITLE
Fix header anchor style

### DIFF
--- a/src/components/__snapshots__/header.test.tsx.snap
+++ b/src/components/__snapshots__/header.test.tsx.snap
@@ -39,9 +39,6 @@ exports[`Header Complete 1`] = `
 }
 
 .emotion-0 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
   white-space: nowrap;
   color: black;
   -webkit-text-decoration: none;
@@ -170,9 +167,6 @@ exports[`Header Only Title 1`] = `
 }
 
 .emotion-0 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
   white-space: nowrap;
   color: black;
   -webkit-text-decoration: none;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -44,7 +44,6 @@ function Header() {
             href="/"
             title={state.i18n.header.mainLinkDescription}
             css={{
-              flex: 1,
               whiteSpace: "nowrap",
               color: "black",
               textDecoration: "none"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8507974/80898584-af446900-8cca-11ea-8d20-036ae57ae888.png)

I'm removing `flex: 1` because I don't think this whole space should be clickable