### PR TITLE
Fix article with no description og

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,12 +16,22 @@
   "env": {
     "node": true,
     "es6": true,
-    "jest": true,
+    "jest": true
   },
   "globals": {
     "page": true,
     "browser": true,
     "context": true,
     "jestPuppeteer": true
+  },
+  "rules": {
+    "unicorn/prevent-abbreviations": [
+      "error",
+      {
+        "whitelist": {
+          "props": true
+        }
+      }
+    ]
   }
 }

--- a/end-to-end.test.js
+++ b/end-to-end.test.js
@@ -119,6 +119,34 @@ describe("End to End", () => {
     );
   });
 
+  test("Article Page without description", async () => {
+    await page.goto("http://localhost:5000/articles/my-second-article/");
+    await expect(page).toMatch("My Second Article");
+    await expect(page).toMatch("May 24, 2020");
+    await expect(page).toMatch("This is my second article.");
+    await expect(page).toMatch("This article has no description");
+    await expect(page).toMatch("Edit it on GitHub");
+    await expect(page).toMatch("Do you like my content?");
+    await expect(page).toMatch(
+      "Become a Patreon and help me continue writing!"
+    );
+    const ogURLContent = await getMetaTagContent(page, "og:url");
+    expect(ogURLContent).toMatch(
+      "https://contentz.tech/articles/my-second-article/"
+    );
+    const ogImage = await getMetaTagContent(page, "og:image");
+    expect(ogImage).toMatch(
+      "https://i.microlink.io/https%3A%2F%2Fcards.microlink.io%2F%3Fpreset%3Dcontentz%26title%3DMy%20Second%20Article%26description%3D"
+    );
+    expect(ogImage).not.toMatch(
+      "https://i.microlink.io/https%3A%2F%2Fcards.microlink.io%2F%3Fpreset%3Dcontentz%26title%3DMy%20Second%20Article%26description%3DCreate%20Content%2C%20Get%20a%20Highly%20Optimized%20Website"
+    );
+    expect(ogImage).toContain(encodeURIComponent("My Second Article"));
+    expect(ogImage).not.toContain(
+      encodeURIComponent("Create Content, Get a Highly Optimized Website")
+    );
+  });
+
   test("Custom Page", async () => {
     await page.goto("http://localhost:5000/about/");
     await expect(page).toMatch("About me");

--- a/example/articles/my-second-article.mdx
+++ b/example/articles/my-second-article.mdx
@@ -1,0 +1,9 @@
+---
+title: My Second Article
+published: true
+date: "Sun, 24 May 2020 19:00:00 GMT-3"
+---
+
+This is my second article.
+
+This article has no description


### PR DESCRIPTION
`formatOGURL` was taking global description if an article didn't have a description
I added a second article without a description and some tests to it

Example 
![image](https://user-images.githubusercontent.com/8507974/82767896-a0943200-9df0-11ea-8105-3ee576cf18b0.png)
