### PR TITLE
Add video to the frontmatter

### DIFF
--- a/example/articles/article-with-vimeo-video.mdx
+++ b/example/articles/article-with-vimeo-video.mdx
@@ -1,0 +1,9 @@
+---
+title: Article with Vimeo video
+description: Learn more on contentz.tech
+published: true
+date: "Sat, 30 May 2020 19:00:00 GMT-3"
+vimeo-video: 393033698
+---
+
+This is an article with a Vimeo video embedded, the video should be above this content.

--- a/example/articles/article-with-vimeo-video.mdx
+++ b/example/articles/article-with-vimeo-video.mdx
@@ -3,7 +3,7 @@ title: Article with Vimeo video
 description: Learn more on contentz.tech
 published: true
 date: "Sat, 30 May 2020 19:00:00 GMT-3"
-vimeo-video: 393033698
+vimeo: 393033698
 ---
 
 This is an article with a Vimeo video embedded, the video should be above this content.

--- a/example/articles/article-with-youtube-video.mdx
+++ b/example/articles/article-with-youtube-video.mdx
@@ -1,0 +1,9 @@
+---
+title: Article with Youtube video
+description: Learn more on contentz.tech
+published: true
+date: "Sat, 30 May 2020 19:00:00 GMT-3"
+youtube-video: dQw4w9WgXcQ
+---
+
+This is an article with a Youtube video embedded, the video should be above this content.

--- a/example/articles/article-with-youtube-video.mdx
+++ b/example/articles/article-with-youtube-video.mdx
@@ -3,7 +3,7 @@ title: Article with Youtube video
 description: Learn more on contentz.tech
 published: true
 date: "Sat, 30 May 2020 19:00:00 GMT-3"
-youtube-video: dQw4w9WgXcQ
+youtube: dQw4w9WgXcQ
 ---
 
 This is an article with a Youtube video embedded, the video should be above this content.

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/react-in-jsx-scope */
 import { jsx } from "@emotion/core";
 import ui from "./ui";
 import { Title, Description, Date } from "./lead";
@@ -12,6 +13,7 @@ import { IArticle } from "../getters/articles";
 import { IPage } from "../getters/pages";
 import Share from "./icons/share";
 import { FunctionComponent } from "react";
+import Video from "./video";
 
 interface LayoutProps {
   data: IArticle | IPage;
@@ -19,13 +21,13 @@ interface LayoutProps {
   Component: FunctionComponent<{ components: any }>;
 }
 
-function TOCWrapper(props: any) {
+function TOCWrapper(props: any): JSX.Element {
   return (
     <aside
       {...props}
       css={{
         a: {
-          color: "black"
+          color: "black",
         },
         ul: {
           listStyleType: "none",
@@ -33,21 +35,21 @@ function TOCWrapper(props: any) {
           marginLeft: 0,
           ul: {
             listStyleType: "square",
-            paddingLeft: "1em"
-          }
+            paddingLeft: "1em",
+          },
         },
         "@media (min-width: 1400px)": {
           position: "absolute",
           right: "110%",
           width: "30vw",
-          maxWidth: "250px"
-        }
+          maxWidth: "250px",
+        },
       }}
     />
   );
 }
 
-function Layout({ data, TOC, Component }: LayoutProps) {
+function Layout({ data, TOC, Component }: LayoutProps): JSX.Element {
   return (
     <div css={{ position: "relative" }}>
       <Header />
@@ -60,8 +62,8 @@ function Layout({ data, TOC, Component }: LayoutProps) {
           "@media (max-width: 40em)": {
             fontSize: "0.9em",
             boxSizing: "border-box",
-            padding: "0 2em"
-          }
+            padding: "0 2em",
+          },
         }}
       >
         {data.date && <Date date={data.date} />}
@@ -74,6 +76,9 @@ function Layout({ data, TOC, Component }: LayoutProps) {
         )}
         {data.type === ContentType.Article && data.translated_to && (
           <Translated.To translations={data.translated_to} />
+        )}
+        {(data["youtube-video"] || data["vimeo-video"]) && (
+          <Video youtube={data["youtube-video"]} vimeo={data["vimeo-video"]} />
         )}
         <Component components={ui} />
         {data.type === ContentType.Article && data.next && (
@@ -91,7 +96,7 @@ function Layout({ data, TOC, Component }: LayoutProps) {
               display: "inline-flex",
               fontSize: "0.8em",
               padding: 0,
-              marginRight: "1em"
+              marginRight: "1em",
             }}
             id="share"
             style={{ display: "none" }}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -77,8 +77,8 @@ function Layout({ data, TOC, Component }: LayoutProps): JSX.Element {
         {data.type === ContentType.Article && data.translated_to && (
           <Translated.To translations={data.translated_to} />
         )}
-        {(data["youtube-video"] || data["vimeo-video"]) && (
-          <Video youtube={data["youtube-video"]} vimeo={data["vimeo-video"]} />
+        {(data.youtube || data.vimeo) && (
+          <Video youtube={data.youtube} vimeo={data.vimeo} />
         )}
         <Component components={ui} />
         {data.type === ContentType.Article && data.next && (

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -1,17 +1,22 @@
+/* eslint-disable react/react-in-jsx-scope */
 import { jsx } from "@emotion/core";
 import Card from "./card";
 
-function format(id: string): string {
+function formatYoutube(id: string | undefined): string {
   return `https://www.youtube.com/embed/${id}`;
 }
 
+function formatVimeo(id: string | undefined): string {
+  return `https://player.vimeo.com/video/${id}`;
+}
+
 interface VideoProps {
-  youtube: string;
-  src?: string;
+  youtube: string | undefined;
+  vimeo: string | undefined;
   caption?: string;
 }
 
-function Video({ youtube, src = format(youtube), caption }: VideoProps) {
+function Video({ youtube, vimeo, caption }: VideoProps): JSX.Element {
   return (
     <Card>
       <div
@@ -21,19 +26,19 @@ function Video({ youtube, src = format(youtube), caption }: VideoProps) {
           paddingBottom: "56.25%;",
           paddingTop: "25px",
           height: 0,
-          marginBottom: caption ? "0.5em" : 0
+          marginBottom: caption ? "0.5em" : 0,
         }}
       >
         <iframe
-          src={src}
-          title={caption || youtube ? "YouTube Video" : "Videp"}
+          src={youtube ? formatYoutube(youtube) : formatVimeo(vimeo)}
+          title={caption || youtube ? "YouTube Video" : "Video"}
           css={{
             border: "none",
             position: "absolute",
             top: 0,
             left: 0,
             width: "100%",
-            height: "100%"
+            height: "100%",
           }}
         />
       </div>
@@ -42,7 +47,7 @@ function Video({ youtube, src = format(youtube), caption }: VideoProps) {
           textAlign: "center",
           marginBottom: 0,
           fontSize: "0.8em",
-          color: "rgba(0, 0, 0, 0.7)"
+          color: "rgba(0, 0, 0, 0.7)",
         }}
       >
         {caption}

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -2,17 +2,17 @@
 import { jsx } from "@emotion/core";
 import Card from "./card";
 
-function formatYoutube(id: string | undefined): string {
+function formatYoutube(id?: string): string {
   return `https://www.youtube.com/embed/${id}`;
 }
 
-function formatVimeo(id: string | undefined): string {
+function formatVimeo(id?: string): string {
   return `https://player.vimeo.com/video/${id}`;
 }
 
 interface VideoProps {
-  youtube: string | undefined;
-  vimeo: string | undefined;
+  youtube?: string;
+  vimeo?: string;
   caption?: string;
 }
 
@@ -31,7 +31,7 @@ function Video({ youtube, vimeo, caption }: VideoProps): JSX.Element {
       >
         <iframe
           src={youtube ? formatYoutube(youtube) : formatVimeo(vimeo)}
-          title={caption || youtube ? "YouTube Video" : "Video"}
+          title={caption || "Video"}
           css={{
             border: "none",
             position: "absolute",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -10,10 +10,12 @@ export interface IContent extends IPath {
   canonical_url?: string;
   published?: boolean;
   social?: string;
+  "youtube-video"?: string;
+  "vimeo-video"?: string;
 }
 
 export enum ContentType {
   Article = "article",
   Slide = "slide",
-  Page = "page"
+  Page = "page",
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -10,8 +10,8 @@ export interface IContent extends IPath {
   canonical_url?: string;
   published?: boolean;
   social?: string;
-  "youtube-video"?: string;
-  "vimeo-video"?: string;
+  youtube?: string;
+  vimeo?: string;
 }
 
 export enum ContentType {

--- a/src/getters/articles.ts
+++ b/src/getters/articles.ts
@@ -44,7 +44,7 @@ interface IArticles {
 async function toContent(path: string): Promise<IFile> {
   return {
     content: await readFile(path, "utf8"),
-    ...parsePath(path)
+    ...parsePath(path),
   };
 }
 
@@ -53,13 +53,13 @@ async function toContent(path: string): Promise<IFile> {
  * @param file A file with their content and path
  */
 function toArticle(config: IConfig) {
-  return async function(file: IFile): Promise<IArticle> {
+  return async function (file: IFile): Promise<IArticle> {
     const {
       data,
       content,
       path,
       tmpPath,
-      filePath
+      filePath,
     }: IFrontMatterFile = await readMeta(file);
 
     return {
@@ -71,7 +71,7 @@ function toArticle(config: IConfig) {
       filePath,
       ...(config.repository
         ? { repositoryPath: parseRepositoryPath(config.repository, filePath) }
-        : {})
+        : {}),
     };
   };
 }
@@ -84,7 +84,7 @@ function toArticle(config: IConfig) {
 function toMap(articles: ArticlesMap, article: IArticle): ArticlesMap {
   return {
     ...articles,
-    [article.path]: article
+    [article.path]: article,
   };
 }
 
@@ -118,10 +118,7 @@ async function articles(config: IConfig): Promise<IArticles> {
   const articles = await Promise.all(files.map(toArticle(config)));
   return {
     byPath: articles.reduce(toMap, {}),
-    order: articles
-      .filter(onlyPublished)
-      .sort(byDate)
-      .map(toPath)
+    order: articles.filter(onlyPublished).sort(byDate).map(toPath),
   };
 }
 


### PR DESCRIPTION
Adds support for a youtube video or vimeo video to be displayed on the frontmatter of an article or page through `youtube-video` and `vimeo-video`

Close #478 